### PR TITLE
Fix writing image to Cloudant

### DIFF
--- a/actions/write-to-cloudant.js
+++ b/actions/write-to-cloudant.js
@@ -48,6 +48,7 @@ function main(params) {
     request({
       uri: LOGO_URL,
       method: 'GET',
+      encoding: null
     }, function(err, response, body) {
       if (err) {
         reject();


### PR DESCRIPTION
`encoding: null` was added so that request on `LOGO_URL` will not encode the body in string. Without setting the encoding to _null_, the action stores a string that results in garbled data instead of an image.